### PR TITLE
Adds good-console to temporary disable config

### DIFF
--- a/temporarilyDisable.json
+++ b/temporarilyDisable.json
@@ -60,6 +60,18 @@
             "@hapi/crumb"
           ],
           "allowedVersions": "<8"
+        },
+        {
+          "packageNames": [
+            "@hapi/good-console"
+          ],
+          "allowedVersions": "<9"
+        },
+        {
+          "packageNames": [
+            "@hapi/good"
+          ],
+          "allowedVersions": "<9"
         }
     ]
 }


### PR DESCRIPTION
disable good-console because it depends on "@hapi/hoek": "9.x.x" & "@hapi/joi": "17.x.x"